### PR TITLE
chore: update TypeScript to version 5.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "prisma": "^5.3.0",
     "rimraf": "^3.0.2",
     "tsc-watch": "^6.0.0",
-    "typescript": "^4.9.4"
+    "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
upgraded the `typescript` package version to latest, because using version `^4.9.4` created an error in the `fastify` package when `tsc --build`